### PR TITLE
Fix signature exclusion null value problem

### DIFF
--- a/src/RpcUtils.php
+++ b/src/RpcUtils.php
@@ -160,7 +160,7 @@ class RpcUtils
 
         $params = [];
         foreach ($query as $k => $v) {
-            if (!empty($v)) {
+            if ($v!==null) {
                 //对参数名称和参数值进行 URL 编码
                 $k = rawurlencode($k);
                 $v = rawurlencode($v);


### PR DESCRIPTION
Reference VMS business, CalledShowNumber is required and can be an empty string.Participation signature

该提交修复：
提交参数为：空字符串、数值 "0" 等非 null 值的必填参数、可选参数无法参与签名问题。
fix:
The submission parameters are: empty string, number "0" and other non null value required parameters and optional parameters can not participate in the signature problem.

可能受影响范围：
依赖此签名的请求参数值为 空字符串、数值0 等曾被排除签名，修改后将参与签名，可能会有签名无法匹配问题。VMS 验证码服务正常，其它未测试。